### PR TITLE
time stamp function now modularized

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,9 +33,11 @@ gulp.task('sass:watch', function () {
 
 gulp.task('js', function () {
     // comment out this block - linter too strict ***************
-    return gulp.src('./js/get.js')
+    gulp.src('./js/tmStmp.js')
     .pipe(jslint({browser: true, sloppy: true, node: true}))
-    return gulp.src('./js/send.js')
+    gulp.src('./js/get.js')
+    .pipe(jslint({browser: true, sloppy: true, node: true}))
+    gulp.src('./js/send.js')
     .pipe(jslint({browser: true, sloppy: true, node: true}))
     //*********************************************************//
     return gulp.src('./js/app.js')

--- a/js/app.js
+++ b/js/app.js
@@ -1,9 +1,11 @@
 
+var tmStmp = require('./tmStmp');
 var getMsgs = require('./get');
 var sendMsg = require('./send');
 
 window.addEventListener('load', function() {
 
+   tmStmp();
    getMsgs();
    document.getElementById('submit').addEventListener('click', sendMsg);
 

--- a/js/get.js
+++ b/js/get.js
@@ -1,55 +1,6 @@
 
 module.exports = function getMsgs() { 
 
-   // format timestamp
-   function setTimeStmp(str) {
-   
-   var current = new Date();
-   var ts = new Date(str);
-   var month = (ts.getMonth() + 1).toString();
-   var day = ts.getDate().toString();
-   var year = ts.getFullYear().toString();
-   // format hours for 12-hour clock
-   var hours = '';
-   var period = '';
-   switch(true) {
-      case (ts.getHours() === 0):
-         hours = '12';
-         period = ' am';
-         break;
-      case (ts.getHours() < 12):
-         hours = ts.getHours().toString();
-         period = ' am';
-         break;
-      case (ts.getHours() === 12):
-         hours = ts.getHours().toString();
-         period = ' pm';
-         break;
-      case (ts.getHours() >= 13):
-         hours = (ts.getHours() - 12).toString();
-         period = ' pm';
-         break;
-   }
-   // format minutes
-   var minutes = '';
-   if (ts.getMinutes() < 10) {
-      minutes = '0' + ts.getMinutes().toString();
-   } else {
-      minutes = ts.getMinutes().toString();
-   }
-
-   // set relative time stamp
-   var relStmp = '';
-   if (ts.getDate() === current.getDate()) {
-      relStmp = 'Today, ' + hours + ':' + minutes + period;
-   } else if (ts.getDate() === (current.getDate() - 1)) {
-      relStmp = 'Yesterday, ' + hours + ':' + minutes + period;
-   } else {
-      relStmp = month + '/' + day + '/' + year + ', ' + hours + ':' + minutes + period;
-   }
-   return relStmp;
-}
-
    // counter for getRequest.onload()
    var count = 0;
    // container (parent element) for retrieved chat

--- a/js/tmStmp.js
+++ b/js/tmStmp.js
@@ -1,0 +1,48 @@
+   // format timestamp
+   function setTimeStmp(str) {
+   
+   var current = new Date();
+   var ts = new Date(str);
+   var month = (ts.getMonth() + 1).toString();
+   var day = ts.getDate().toString();
+   var year = ts.getFullYear().toString();
+   // format hours for 12-hour clock
+   var hours = '';
+   var period = '';
+   switch(true) {
+      case (ts.getHours() === 0):
+         hours = '12';
+         period = ' am';
+         break;
+      case (ts.getHours() < 12):
+         hours = ts.getHours().toString();
+         period = ' am';
+         break;
+      case (ts.getHours() === 12):
+         hours = ts.getHours().toString();
+         period = ' pm';
+         break;
+      case (ts.getHours() >= 13):
+         hours = (ts.getHours() - 12).toString();
+         period = ' pm';
+         break;
+   }
+   // format minutes
+   var minutes = '';
+   if (ts.getMinutes() < 10) {
+      minutes = '0' + ts.getMinutes().toString();
+   } else {
+      minutes = ts.getMinutes().toString();
+   }
+
+   // set relative time stamp
+   var relStmp = '';
+   if (ts.getDate() === current.getDate()) {
+      relStmp = 'Today, ' + hours + ':' + minutes + period;
+   } else if (ts.getDate() === (current.getDate() - 1)) {
+      relStmp = 'Yesterday, ' + hours + ':' + minutes + period;
+   } else {
+      relStmp = month + '/' + day + '/' + year + ', ' + hours + ':' + minutes + period;
+   }
+   return relStmp;
+}

--- a/js/tmStmp.js
+++ b/js/tmStmp.js
@@ -1,3 +1,5 @@
+
+module.exports = function tmStmp() { 
    // format timestamp
    function setTimeStmp(str) {
    
@@ -45,4 +47,5 @@
       relStmp = month + '/' + day + '/' + year + ', ' + hours + ':' + minutes + period;
    }
    return relStmp;
-}
+   }
+};


### PR DESCRIPTION
This PR will modularize the time stamp function. It removed the timestamp function from get.js so that get.js handles only retrieving chat from the server. The timestamp function is called within the logic of get.js so that what is served to the view has a properly formatted time stamp.
